### PR TITLE
deployment: point out intended workflow

### DIFF
--- a/docusaurus/docs/dev-docs/deployment.md
+++ b/docusaurus/docs/dev-docs/deployment.md
@@ -24,6 +24,11 @@ In addition to the official deployment guides maintained by Strapi that are foun
 
 ## General guidelines
 
+:::caution
+Content should not be deployed from development to production.
+Use git and development mode to create models first, deploy the changes to production, and then add content on the production instance.
+:::
+
 ### Hardware and software requirements
 
 To provide the best possible environment for Strapi the following requirements apply to development (local) and staging and production workflows.


### PR DESCRIPTION
### What does it do?

Admins are confused, contractors create content on their dev machine and are unhappy that they have to redo their work on prod...

### Why is it needed?

Devops will try ludicrous things in order to get the content from developers into production.
Tell them that's not something they should be doing :-)
